### PR TITLE
add a way to change parameter description

### DIFF
--- a/docs/help-command.rst
+++ b/docs/help-command.rst
@@ -127,3 +127,8 @@ help_autocomplete
 ~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: help_autocomplete
+
+describe_help_command
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: describe_help_command

--- a/starlight/star_commands/help_command/injector.py
+++ b/starlight/star_commands/help_command/injector.py
@@ -115,7 +115,7 @@ class _HelpHybridCommandImpl(commands.HybridCommand):
             except KeyError:
                 continue
             else:
-                param = param.replace(description=str(description))
+                self.params[name] = param.replace(description=str(description))
 
     def __inject_callback_meta(self, inject: commands.HelpCommand):
         if not self.with_app_command:


### PR DESCRIPTION
this PR adds a little note to the reference for `HelpHybridCommand.command_callback()` to explain how to change the parameter description to something other than default ellipsis~ i got stuck on this for a bit so i felt it would be good to add